### PR TITLE
Add responsive images by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,9 +313,33 @@ Likewise, if you have a nested list, make sure that nested items are indented by
 
 Local images referenced in a Markdown file are automatically published to Confluence as attachments to the page.
 
+#### Responsive Images
+
+By default, all images are inserted as responsive, meaning they:
+- Are centered on the page
+- Automatically adapt to the width of the surrounding content area
+- Have no fixed width unless explicitly specified
+
+To specify a fixed width for an image, use HTML image syntax with the width attribute:
+
+```markdown
+<!-- Responsive image (default) -->
+![Image description](path/to/image.png)
+
+<!-- Fixed-width image (400 pixels) -->
+<img src="path/to/image.png" width="400" alt="Image description" />
+
+<!-- Fixed-width image with height -->
+<img src="path/to/image.png" width="500" height="300" alt="Image description" />
+```
+
+When you specify an explicit width, the image will maintain that fixed width rather than scaling responsively.
+
+#### SVG Handling
+
 Unfortunately, Confluence struggles with SVG images, e.g. they may only show in *edit* mode, display in a wrong size or text labels in the image may be truncated. (This seems to be a known issue in Confluence.) In order to mitigate the issue, whenever *md2conf* encounters a reference to an SVG image in a Markdown file, it checks whether a corresponding PNG image also exists in the same directory, and if a PNG image is found, it is published instead.
 
-External images referenced with an absolute URL retain the original URL.
+External images referenced with an absolute URL retain the original URL but still follow the responsive behavior unless width is explicitly specified.
 
 ### LaTeX math formulas
 

--- a/md2conf/converter.py
+++ b/md2conf/converter.py
@@ -273,18 +273,22 @@ class ImageAttributes:
 
     def as_dict(self) -> dict[str, str]:
         attributes: dict[str, str] = {}
+        # Always center align all images (both block and inline)
+        attributes[AC_ATTR("align")] = "center"
+        attributes[AC_ATTR("layout")] = "center"
+
         if self.context is FormattingContext.BLOCK:
-            attributes[AC_ATTR("align")] = "center"
-            attributes[AC_ATTR("layout")] = "center"
+            # Only include width-related attributes if explicitly specified
             if self.width is not None:
                 attributes[AC_ATTR("original-width")] = str(self.width)
-            if self.height is not None:
-                attributes[AC_ATTR("original-height")] = str(self.height)
-            if self.width is not None:
                 attributes[AC_ATTR("custom-width")] = "true"
                 attributes[AC_ATTR("width")] = str(self.width)
+            # Always include height if provided
+            if self.height is not None:
+                attributes[AC_ATTR("original-height")] = str(self.height)
 
         elif self.context is FormattingContext.INLINE:
+            # Only include width/height if explicitly specified
             if self.width is not None:
                 attributes[AC_ATTR("width")] = str(self.width)
             if self.height is not None:

--- a/tests/source/responsive-images.md
+++ b/tests/source/responsive-images.md
@@ -1,0 +1,11 @@
+<!-- confluence-page-id: 00000000000 -->
+
+## Responsive Images Test
+
+![Default responsive image](figure/raster.png)
+
+<img src="figure/vector.svg" width="400" alt="Image with explicit width" />
+
+<img src="figure/raster.png" height="300" alt="Image with explicit height" />
+
+<img src="figure/vector.svg" width="500" height="400" alt="Image with both width and height" />

--- a/tests/target/images.xml
+++ b/tests/target/images.xml
@@ -24,8 +24,8 @@
   <ri:url ri:value="http://confluence.atlassian.com/images/logo/confluence_48_trans.png"/>
   <ac:caption>An image at an external location</ac:caption>
 </ac:image>
-<ac:image ac:align="center" ac:layout="center" ac:original-width="24" ac:original-height="24" ac:custom-width="true" ac:width="24">
+<ac:image ac:align="center" ac:layout="center" ac:original-width="24" ac:custom-width="true" ac:width="24" ac:original-height="24">
   <ri:url ri:value="http://confluence.atlassian.com/images/logo/confluence_48_trans.png"/>
 </ac:image>
 <h2>Inline images</h2>
-<p>This is an <ac:image ac:alt="inline image"><ri:url ri:value="http://confluence.atlassian.com/images/logo/confluence_48_trans.png"/></ac:image> at an external location.</p>
+<p>This is an <ac:image ac:align="center" ac:layout="center" ac:alt="inline image"><ri:url ri:value="http://confluence.atlassian.com/images/logo/confluence_48_trans.png"/></ac:image> at an external location.</p>

--- a/tests/target/responsive-images.xml
+++ b/tests/target/responsive-images.xml
@@ -1,0 +1,22 @@
+<ac:structured-macro ac:name="info" ac:schema-version="1">
+  <ac:rich-text-body>
+    <p>This page has been generated with a tool.</p>
+  </ac:rich-text-body>
+</ac:structured-macro>
+<h2>Responsive Images Test</h2>
+<ac:image ac:align="center" ac:layout="center" ac:alt="Default responsive image">
+  <ri:attachment ri:filename="figure_raster.png"/>
+  <ac:caption>Default responsive image</ac:caption>
+</ac:image>
+<ac:image ac:align="center" ac:layout="center" ac:original-width="400" ac:custom-width="true" ac:width="400" ac:alt="Image with explicit width">
+  <ri:attachment ri:filename="figure_vector.svg"/>
+  <ac:caption>Image with explicit width</ac:caption>
+</ac:image>
+<ac:image ac:align="center" ac:layout="center" ac:original-height="300" ac:alt="Image with explicit height">
+  <ri:attachment ri:filename="figure_raster.png"/>
+  <ac:caption>Image with explicit height</ac:caption>
+</ac:image>
+<ac:image ac:align="center" ac:layout="center" ac:original-width="500" ac:custom-width="true" ac:width="500" ac:original-height="400" ac:alt="Image with both width and height">
+  <ri:attachment ri:filename="figure_vector.svg"/>
+  <ac:caption>Image with both width and height</ac:caption>
+</ac:image>

--- a/tests/test_conversion.py
+++ b/tests/test_conversion.py
@@ -169,6 +169,29 @@ class TestConversion(TypedTestCase):
 
         self.assertEqual(actual, expected)
 
+    def test_responsive_images(self) -> None:
+        """
+        Test that images are responsive by default, with optional explicit width/height.
+        This test verifies:
+        1. Default responsive image (no width/height attributes)
+        2. Image with explicit width (includes width and custom-width attributes)
+        3. Image with explicit height (includes height attribute)
+        4. Image with both width and height (includes both attributes)
+        """
+        _, doc = ConfluenceDocument.create(
+            self.source_dir / "responsive-images.md",
+            ConfluenceDocumentOptions(),
+            self.source_dir,
+            self.site_metadata,
+            self.page_metadata,
+        )
+        actual = standardize(doc.xhtml())
+
+        with open(self.target_dir / "responsive-images.xml", "r", encoding="utf-8") as f:
+            expected = substitute(self.target_dir, f.read())
+
+        self.assertEqual(actual, expected)
+
     def test_missing_title(self) -> None:
         _, doc = ConfluenceDocument.create(
             self.source_dir / "title.md",


### PR DESCRIPTION
## Summary
- Implements responsive images by default in Confluence pages
- Images are now centered and automatically adapt to content width
- No hard-coded pixel widths unless explicitly requested
- User-specified widths/heights in Markdown are respected

## Implementation Details
- Updated the `ImageAttributes` class to always include alignment/layout center
- Only include width/custom-width when explicitly specified by the user
- Added comprehensive tests for various image scenarios
- Updated README with documentation about responsive image behavior

## Test Plan
- Added dedicated test for responsive images with different scenarios
- Verified all existing tests continue to pass
- Ran static analysis tools (ruff, mypy) to ensure code quality

Fixes the requirements specified in FEATURE.md

🤖 Generated with [Claude Code](https://claude.ai/code)